### PR TITLE
Add SIAv2 example notebook for scale-testing SIA

### DIFF
--- a/SIAV2_Example.ipynb
+++ b/SIAV2_Example.ipynb
@@ -1,0 +1,237 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ba370082-e49b-4d50-8256-c562acf6115d",
+   "metadata": {},
+   "source": [
+    "# Getting images using the new SIAv2 application"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6f3db62-b15c-456c-a7ae-ac16dd7586f3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import random\n",
+    "import requests\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import pyvo\n",
+    "from pyvo.dal import SIA2Service\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.io import fits\n",
+    "from astropy import units as u\n",
+    "from astropy.time import Time\n",
+    "from astropy.utils.data import download_file\n",
+    "from astropy.visualization import imshow_norm, ZScaleInterval\n",
+    "from astropy.visualization.stretch import  SqrtStretch\n",
+    "\n",
+    "from lsst.rsp import get_datalink_result\n",
+    "from lsst.rsp.utils import get_pyvo_auth, get_access_token, get_service_url\n",
+    "from lsst.rsp.service import get_siav2_service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e1c048b-da28-4904-ae2f-025b23946f26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specify the SIA service to use\n",
+    "service = get_siav2_service(\"dp02\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "90dbcfb2-9159-485a-8392-4293675c913b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup auth for datalinker\n",
+    "import requests\n",
+    "s = requests.Session()\n",
+    "tok = get_access_token()\n",
+    "s.headers[\"Authorization\"] = f\"Bearer {tok}\"\n",
+    "auth = pyvo.auth.authsession.AuthSession()\n",
+    "auth.credentials.set(\"lsst-token\", s)\n",
+    "auth.add_security_method_for_url(get_service_url(\"datalink\"), \"lsst-token\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96d6264f-eabb-4d18-9388-84b5fe5eb27d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Execute a query looking for pictures within a circle\n",
+    "# and show them as a table\n",
+    "from astropy import units as u\n",
+    "\n",
+    "coords = SkyCoord(55.777353, -32.544474, unit=(u.deg, u.deg))\n",
+    "\n",
+    "t1 = Time(\"60550.31803461111\", format='mjd')\n",
+    "t2 = Time(\"60550.31838182871\", format='mjd')\n",
+    "\n",
+    "# Create Time objects\n",
+    "results = service.search(\n",
+    "    pos=(coords, 0.10*u.deg),\n",
+    "    time=[t1, t2]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9757fa5d-3ebc-4b2a-aaa8-743fb3145113",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30a542c8-ae18-440b-9d12-5665415e30ca",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Extract the access URL from the result in the first row\n",
+    "dataLinkUrl = random.choice(results).access_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb4a82aa-9826-46ed-aa33-8f16040adf42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(dataLinkUrl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c70bac1a-ceb9-4f14-890a-41ef4c8a7467",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyvo.dal.adhoc import DatalinkResults\n",
+    "dl_result = DatalinkResults.from_result_url(\n",
+    "    dataLinkUrl, session=auth\n",
+    ")\n",
+    "print(dl_result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "976bced7-2c4f-4722-acdf-6da6ed985c81",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Retrieve the datalink votable document and\n",
+    "# show it in the notebook\n",
+    "dl_result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f95b561c-ac30-4c09-92dd-8d4be4eec9a6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Full image of calexp - not a cutout\n",
+    "image_url = dl_result.getrecord(0).get('access_url')\n",
+    "image_url"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff880647-1215-4157-977c-d0933ea0152a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Now let's download the image \n",
+    "filename = download_file(image_url)\n",
+    "filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18d53f7e-9919-4bec-888e-a3a18b74cdb6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "hdulist = fits.open(image_url)\n",
+    "\n",
+    "for hdu in hdulist:\n",
+    "    print(hdu.name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33e1062c-5efa-46e8-979c-e4e84e9d62b0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Let's plot the image and see what it looks like...\n",
+    "image = hdulist[1].data\n",
+    "\n",
+    "fig = plt.figure()\n",
+    "ax = fig.add_subplot(1, 1, 1)\n",
+    "im = imshow_norm(image, ax, origin='lower', interval=ZScaleInterval(), stretch=SqrtStretch(), cmap='gray')\n",
+    "fig.colorbar(im[0])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Shall I remove the rest of the notebook that uses fetches the datalink from the results, downloads the image and displays it?
In other words if we just want to test SIA, everything after print(results) could go.