### PR TITLE
DM-51295: Add test notebook for semaphore

### DIFF
--- a/semaphore_broadcasts.ipynb
+++ b/semaphore_broadcasts.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6619d730-4388-4025-a6ab-e7210e1333ac",
+   "metadata": {},
+   "source": [
+    "# Semaphore broadcast test\n",
+    "\n",
+    "This notebook, for Mobu, gets broadcasts from [Semaphore's](https://github.com/lsst-sqre/semaphore) `/v1/broadcasts` endpoint, which is the same behaviour as any visitor to Squareone."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd282181-6612-4af5-8e29-bd62d1b70222",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import httpx\n",
+    "import lsst.rsp\n",
+    "from pprint import pprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b4363df-3933-40ae-a5b3-3a7408b0be5c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = lsst.rsp.client.RSPClient(\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76720ce5-bd3f-47be-ab94-675e77c031d7",
+   "metadata": {},
+   "source": [
+    "Get the current broadcasts from Semaphore:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c995e13-ecfe-40e2-b662-a7019ed1a034",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = await client.get(\"/semaphore/v1/broadcasts\")\n",
+    "r.raise_for_status()\n",
+    "broadcasts = r.json()\n",
+    "assert isinstance(broadcasts, list)\n",
+    "pprint(broadcasts, indent=2) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0470f2ff-57a5-4f50-af9a-1d17e9d1d4eb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook makes a simple request to Semaphore's broadcasts endpoint, which is the same as any visitor to Squareone.