### PR TITLE
DM-51295: Add basic squareone test

### DIFF
--- a/squareone_basic.ipynb
+++ b/squareone_basic.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ab8d4756-22b7-4a01-a7e0-f530b9793ac5",
+   "metadata": {},
+   "source": [
+    "# Squareone basic load test\n",
+    "\n",
+    "This notebook requests the server-rendered HTML for the `/` endpoint. The load test isn't representative because it does not request other assets like the CSS, JavaScript, and image assets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ae1cf22-0b62-413e-8423-ba290ad3ba58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import httpx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d54d7e3e-9c87-4085-a353-c0641abe557d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = os.environ[\"EXTERNAL_INSTANCE_URL\"]\n",
+    "r = httpx.get(url)\n",
+    "r.raise_for_status()\n",
+    "print(r.text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df3ed3d3-a92c-40f0-9c87-8e45ea9edd69",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook requests the server-rendered HTML for the / endpoint. The load test isn't representative because it does not request other assets like the CSS, JavaScript, and image assets.